### PR TITLE
Try a PR to register the workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -3,6 +3,7 @@ name: Update
 on:
   schedule:
     - cron: '0 0 * * *'
+  pull_request:
   workflow_dispatch:
 jobs:
   update:


### PR DESCRIPTION
The GitHub Action that updates `main` was moved to the `sync` branch and is suddenly no longer recognized at all. I'm just trying random stuff I read on Stack Overflow to fix it.